### PR TITLE
client certificate authentication

### DIFF
--- a/src/ios/CDVWKWebViewFileXhr.m
+++ b/src/ios/CDVWKWebViewFileXhr.m
@@ -35,6 +35,8 @@
 #import "CDVWKWebViewFileXhr.h"
 #import <Cordova/CDV.h>
 
+#import "ClientCertificate.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 
@@ -314,19 +316,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)URLSession:(NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
  completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential * _Nullable credential))completionHandler {
-    
+    // ---
+    NSLog(@"URL session auth challenge");
     if (_allowsInsecureLoads) {
         SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
         if (serverTrust) {
           CFDataRef exceptions = SecTrustCopyExceptions (serverTrust);
           SecTrustSetExceptions (serverTrust, exceptions);
           CFRelease (exceptions);
+          NSLog(@"FINISH URL session auth challenge with credential from server trust");
           completionHandler (NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:serverTrust]); // FortityFalsePositive
          
           return;
         }
     }
-    completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+    [ClientCertificate didReceiveAuthenticationChallenge:challenge completionHandler:completionHandler withOptionsNullable:nil];
+    NSLog(@"FINISHED URL session auth challenge callback");
 }
 
 


### PR DESCRIPTION
Adds support for client certificate authentication, using this plugin for the bulk of the functionality: https://github.com/cordova-ccafix/cordova-plugin-client-certificate-support

These changes require `cordova-plugin-client-certificate-support` with changes from <https://github.com/cordova-ccafix/cordova-plugin-client-certificate-support/pull/12> in order to build properly. Here is the recommended command to install the prerequisite plugin:

    cordova plugin add github:cordova-ccafix/cordova-plugin-client-certificate-support#expose-auth-challenge-callback

TODO:

- [ ] add explicit plugin dependency
- [ ] clean up comments
- [ ] clean up logging
- [x] This PR is targeting an unstable @brodybits fork; need to get @brodybits fork stable first
- [ ] I may also rename the XHR plugin version that will provide this client certificate authentication functionality.